### PR TITLE
Update api-grammar doc

### DIFF
--- a/go-zero.dev/cn/api-grammar.md
+++ b/go-zero.dev/cn/api-grammar.md
@@ -365,6 +365,8 @@ type Foo{
 > 详情见下表。
 
 * tag表
+
+  绑定参数时，以下四个tag不能同时存在，只能选择其中一个
   <table>
   <tr>
     <td>tag key</td> <td>描述</td> <td>提供方</td><td>有效范围 </td> <td>示例 </td>

--- a/go-zero.dev/cn/api-grammar.md
+++ b/go-zero.dev/cn/api-grammar.md
@@ -366,7 +366,7 @@ type Foo{
 
 * tag表
 
-  绑定参数时，以下四个tag不能同时存在，只能选择其中一个
+  绑定参数时，以下四个tag只能选择其中一个
   <table>
   <tr>
     <td>tag key</td> <td>描述</td> <td>提供方</td><td>有效范围 </td> <td>示例 </td>

--- a/go-zero.dev/en/api-grammar.md
+++ b/go-zero.dev/en/api-grammar.md
@@ -372,6 +372,8 @@ type Foo{
 > See the table below for details.
 
 * tag table
+
+  When binding parameters, the following four tags cannot exist at the same time. Only one of them can be selected
   <table>
   <tr>
     <td>tag key</td> <td>Description</td> <td>Provider</td><td>Effective Coverage</td> <td>Example</td>

--- a/go-zero.dev/en/api-grammar.md
+++ b/go-zero.dev/en/api-grammar.md
@@ -373,7 +373,7 @@ type Foo{
 
 * tag table
 
-  When binding parameters, the following four tags cannot exist at the same time. Only one of them can be selected
+  When binding parameters, only one of the following four tags can be selected
   <table>
   <tr>
     <td>tag key</td> <td>Description</td> <td>Provider</td><td>Effective Coverage</td> <td>Example</td>


### PR DESCRIPTION
添加type中绑定参数的说明，四个tag只能选择其中一个