### PR TITLE
当prefix为"/api",而不是"api"时，我IDEA的Goctl插件会报错。

### DIFF
--- a/go-zero.dev/cn/api-grammar.md
+++ b/go-zero.dev/cn/api-grammar.md
@@ -486,7 +486,7 @@ path：api请求路径，必须以'/'或者'/:'开头，切不能以'/'结尾，
 </tr>
 
 <tr>
-<td>prefix</td><td>添加路由分组</td><td><code>prefix: /api</code></td>
+<td>prefix</td><td>添加路由分组</td><td><code>prefix: api</code></td>
 </tr>
 </table>
 
@@ -510,7 +510,7 @@ eg1：不规范写法
   jwt: Auth
   group: foo
   middleware: AuthMiddleware
-  prefix /api
+  prefix api
 )
 service foo-api{
   @doc(
@@ -538,7 +538,7 @@ eg2：规范写法（推荐）
   jwt: Auth
   group: foo
   middleware: AuthMiddleware
-  prefix: /api
+  prefix: api
 )
 service foo-api{
   @doc "foo"


### PR DESCRIPTION
Go-zero以工具大于文档为约定，文档的这个地方与工具不太相符，为了严谨我觉得应该修改一下。