### PR TITLE
修改 shorturl.md 文章中关于Model调用缺少传参的补充

### DIFF
--- a/doc/shorturl.md
+++ b/doc/shorturl.md
@@ -485,7 +485,7 @@ rpc/transform
   ```go
   func (l *ExpandLogic) Expand(in *transform.ExpandReq) (*transform.ExpandResp, error) {
     // 手动代码开始
-    res, err := l.svcCtx.Model.FindOne(in.Shorten)
+    res, err := l.svcCtx.Model.FindOne(l.ctx,in.Shorten)
     if err != nil {
       return nil, err
     }
@@ -503,7 +503,7 @@ rpc/transform
   func (l *ShortenLogic) Shorten(in *transform.ShortenReq) (*transform.ShortenResp, error) {
     // 手动代码开始，生成短链接
     key := hash.Md5Hex([]byte(in.Url))[:6]
-    _, err := l.svcCtx.Model.Insert(model.Shorturl{
+    _, err := l.svcCtx.Model.Insert(l.ctx,model.Shorturl{
       Shorten: key,
       Url:     in.Url,
     })


### PR DESCRIPTION
调用Model需要传递l.ctx