### PR TITLE
自定义错误的函数应该是SetErrorHandlerCtx

### DIFF
--- a/go-zero.dev/cn/error-handle.md
+++ b/go-zero.dev/cn/error-handle.md
@@ -142,7 +142,7 @@ Content-Length: 19
         handler.RegisterHandlers(server, ctx)
     
         // 自定义错误
-        httpx.SetErrorHandler(func(err error) (int, interface{}) {
+	httpx.SetErrorHandlerCtx(func(ctx context.Context, err error) (int, any) {
             switch e := err.(type) {
             case *errorx.CodeError:
                 return http.StatusOK, e.Data()


### PR DESCRIPTION
我是用的go-zero v1.5.0版本的框架，goctl的版本是1.5.1，通过`goctl api go -api user.api -dir .`命令生成的API相关文件，其中的`user/internal/handler/*handler.go`文件关于错误的处理使用的是`httpx.ErrorCtx(r.Context(), w, err)`函数，所以，如果想实现自定义错误，需要将`httpx.SetErrorHandler()`改为`httpx.SetErrorHandlerCtx()`